### PR TITLE
arguments switched in getOptions

### DIFF
--- a/R/Convert.R
+++ b/R/Convert.R
@@ -529,7 +529,7 @@ H5ADToH5Seurat <- function(
   }
   # Add cell-level metadata
   if (source$exists(name = 'obs') && inherits(x = source[['obs']], what = 'H5Group')) {
-    if (!source[['obs']]$exists(name = '__categories') && !getOption("SeuratDisk.dtypes.dataframe_as_group", x = TRUE)) {
+    if (!source[['obs']]$exists(name = '__categories') && !getOption(x="SeuratDisk.dtypes.dataframe_as_group", default = TRUE)) {
       warning(
         "Conversion from H5AD to h5Seurat allowing compound datasets is not yet implemented",
         call. = FALSE,


### PR DESCRIPTION
Hi,

came across this when trying to convert scanpy/AnnData into Seurat.
in this particular `getOptions()` call, the arguments are switched. 