### PR TITLE
corrected _index already exists error in dfile[['raw/var']]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratDisk
 Type: Package
 Title: Interfaces for HDF5-Based Single Cell File Formats
-Version: 0.0.0.9018
-Date: 2021-01-25
+Version: 0.0.0.9019
+Date: 2021-03-04
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'phoffman@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'ctb', comment = c(ORCID = '0000-0001-9448-8833'))

--- a/R/Convert.R
+++ b/R/Convert.R
@@ -1129,6 +1129,9 @@ H5SeuratToH5AD <- function(
       dfile[['raw']]$create_group(name = 'var')
     }
     # Add feature names
+    if (Exists(x = dfile[['raw/var']], name = rownames)) {
+      dfile[['raw/var']]$link_delete(name = rownames)
+    }
     dfile[['raw/var']]$create_dataset(
       name = rownames,
       robj = assay.group[['features']][],


### PR DESCRIPTION
was getting an error for dfile['raw/var'] similar to the one mentioned in issue #44  in line https://github.com/mojaveazure/seurat-disk/blob/3848eab6fcb9ead489cabdad464921e43561e28c/R/Convert.R#L1132