### PR TITLE
Fixed filename bug h5Seurat vs of h5seurat

### DIFF
--- a/R/SaveH5Seurat.R
+++ b/R/SaveH5Seurat.R
@@ -162,13 +162,13 @@ as.h5Seurat.H5File <- function(x, ...) {
 #'
 as.h5Seurat.Seurat <- function(
   x,
-  filename = paste0(Project(object = x), '.h5seurat'),
+  filename = paste0(Project(object = x), '.h5Seurat'),
   overwrite = FALSE,
   verbose = TRUE,
   ...
 ) {
   if (!grepl(pattern = '^h5seurat$', x = file_ext(x = filename), ignore.case = TRUE)) {
-    filename <- paste0(filename, '.h5seurat')
+    filename <- paste0(filename, '.h5Seurat')
   }
   if (file.exists(filename)) {
     if (overwrite) {


### PR DESCRIPTION
In function `as.h5Seurat.Seurat` the `filename` argument was set with `'.h5seurat'` while in all other functions in the file it was set with `'.h5Seurat'`.