### PR TITLE
Check if images is NULL in GetImages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratDisk
 Type: Package
 Title: Interfaces for HDF5-Based Single Cell File Formats
-Version: 0.0.0.9021
-Date: 2023-03-16
+Version: 0.0.0.9022
+Date: 2025-08-16
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'phoffman@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'ctb', comment = c(ORCID = '0000-0001-9448-8833'))

--- a/R/GetObject.R
+++ b/R/GetObject.R
@@ -188,7 +188,7 @@ GetGraphs <- function(graphs, index, assays = NULL) {
 #' @rdname GetObject
 #'
 GetImages <- function(images, index, assays = NULL) {
-  if (isFALSE(x = images)) {
+  if (isFALSE(x = images) | is.null(x = images)) {
     return(NULL)
   } else if (!is.null(x = images) && all(is.na(x = images))) {
     return(index$global$images)


### PR DESCRIPTION
Encountered the same issue as #191, which seems to happen if a h5seurat file has NULL in the images slot (can happen for older files). This is a simple change to the `GetImages()` function that should solve the problem.


Example:

data: https://atlas.fredhutch.org/data/nygc/multimodal/pbmc_multimodal.h5seurat

```r
library(Seurat)
library(SeuratDisk)

obj <- LoadH5Seurat("pbmc_multimodal.h5seurat")
```


Closes #191