### PR TITLE
fix SeuratObject 5 slot= compat and GetImages unlist bug

### DIFF
--- a/R/AssembleObject.R
+++ b/R/AssembleObject.R
@@ -65,7 +65,7 @@ AssembleAssay <- function(assay, file, slots = NULL, verbose = TRUE) {
   Key(object = obj) <- Key(object = assay.group)
   # Add remaining slots
   for (slot in slots) {
-    if (IsMatrixEmpty(x = GetAssayData(object = obj, slot = slot))) {
+    if (IsMatrixEmpty(x = GetAssayData_compat(object = obj, slot = slot))) {
       if (verbose) {
         message("Adding ", slot, " for ", assay)
       }
@@ -76,7 +76,7 @@ AssembleAssay <- function(assay, file, slots = NULL, verbose = TRUE) {
       } else {
         features
       }
-      obj <- SetAssayData(object = obj, slot = slot, new.data = dat)
+      obj <- SetAssayData_compat(object = obj, slot = slot, new.data = dat)
     }
   }
   # Add meta features

--- a/R/GetObject.R
+++ b/R/GetObject.R
@@ -207,7 +207,7 @@ GetImages <- function(images, index, assays = NULL) {
       return(index[[x]]$images)
     }
   )
-  assays.images <- unique(x = c(unlist(x = assays.images, index$global$images)))
+  assays.images <- unique(x = c(unlist(x = assays.images), index$global$images))
   return(intersect(x = images, y = assays.images))
 }
 

--- a/R/WriteH5Group.R
+++ b/R/WriteH5Group.R
@@ -239,7 +239,7 @@ setMethod(
     # Write out expression data
     # TODO: determine if empty matrices should be present
     for (i in c('counts', 'data', 'scale.data')) {
-      dat <- GetAssayData(object = x, slot = i)
+      dat <- GetAssayData_compat(object = x, slot = i)
       if (!IsMatrixEmpty(x = dat)) {
         if (verbose) {
           message("Adding ", i, " for ", name)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -71,6 +71,18 @@ spatial.version <- '3.1.5.9900'
 # Internal utility functions
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+# SeuratObject 5 renamed the `slot` argument to `layer` in GetAssayData /
+# SetAssayData and made the old name defunct.  These shims try the new name
+# first and fall back to the old name so the package works with both v4 and v5.
+GetAssayData_compat <- function(object, slot) {
+  tryCatch(GetAssayData(object = object, layer = slot),
+           error = function(e) GetAssayData(object = object, slot = slot))
+}
+SetAssayData_compat <- function(object, slot, new.data) {
+  tryCatch(SetAssayData(object = object, layer = slot, new.data = new.data),
+           error = function(e) SetAssayData(object = object, slot = slot, new.data = new.data))
+}
+
 #' Convert a logical to an integer
 #'
 #' Unlike most programming languages, R has three possible \link[base]{logical}


### PR DESCRIPTION
1. GetAssayData(slot=) and SetAssayData(slot=) are defunct in SeuratObject 5.  

This PR adds GetAssayData_compat / SetAssayData_compat shims in zzz.R that try the new layer= argument first and fall back to slot= for SeuratObject 4. Apply the shims in WriteH5Group.R (save path) and AssembleObject.R (load path).

```r
  # SeuratObject >= 5: this now stops with "slot argument is defunct"
  GetAssayData(object = assay, slot = "counts")
  # fix: try layer= first, fall back to slot= for v4
  GetAssayData_compat(object = assay, slot = "counts")
```

2.  R 4.5 tightened argument checking for `unlist`, now errors on this. This PR fixes an issue in GetObject.R::GetImages where unlist(x = assays.images, index$global$images) passed index$global$images as the `recursive` argument to unlist instead of concatenating it; R 4.5 tightened argument checking and now errors on this.

```r
  # broken: second positional arg becomes recursive=
  unlist(x = assays.images, index$global$images)
  # fix: explicit concatenation after unlisting
  c(unlist(x = assays.images), index$global$images)
```